### PR TITLE
Warn when register_sharding_key() is called with 'bucket_id' key

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Every migration (e. g. `0001_create_my_sharded_space_DATETIME.lua`) should expos
         return true
     end
 ```
-
+Warning! It's not correct to specify 'bucket_id' as a 'key' parameter for register_sharding_key().
+The 'bucket_id' field is a place where the output of sharding function is saved to.
 
 
 ## Limitations

--- a/migrator/utils.lua
+++ b/migrator/utils.lua
@@ -1,3 +1,4 @@
+local log = require('log')
 
 local function value_in(val, arr)
     for i, elem in ipairs(arr) do
@@ -16,8 +17,21 @@ local function compare(a, b)
     return true
 end
 
+
 -- TODO: remove this ugly hack
+---
+--- Set fields that are used for sharding key calculation for a specified space.
+---
+--- @param space_name string name of sharded space
+--- @param key table array of field names that will be used as input of sharding function
+---
 local function register_sharding_key(space_name, key)
+
+    if value_in('bucket_id', key) then
+        log.error("Wrong sharding key: 'bucket_id' is used as input of sharding function for space '"
+            .. space_name .. "'")
+    end
+
     if box.space._ddl_sharding_key == nil then
             local sharding_space = box.schema.space.create('_ddl_sharding_key', {
         format = {

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -153,7 +153,7 @@ for k, configure_func in pairs(cases) do
                             },
                         },
                         is_local = false,
-                        sharding_key = { "bucket_id" },
+                        sharding_key = { "key" },
                         temporary = false,
                     },
 

--- a/test/integration/migrations/03_sharded.lua
+++ b/test/integration/migrations/03_sharded.lua
@@ -19,7 +19,7 @@ return {
             if_not_exists = true,
             unique = false
         })
-        utils.register_sharding_key('sharded', {'bucket_id'})
+        utils.register_sharding_key('sharded', {'key'})
         return nil
     end
 }


### PR DESCRIPTION
As an option we can assert or raise an error here, but I think this can cause a lot of unexpected errors during upgrades .
So currently we display a warning instead of raising an error.