### PR TITLE
api: allow to set storage timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0]
 ### Added:
 - Configurable timeout for storage migrations (gh-66)
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed:
 - Running tests with Tarantool 2.11+
+- Running tests with tarantool/http 1.2.0+ (gh-63)
 
 ## [0.5.0]
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Configurable timeout for storage migrations (gh-66)
 ### Fixed:
 - Running tests with Tarantool 2.11+
 - Running tests with tarantool/http 1.2.0+ (gh-63)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed:
+- Running tests with Tarantool 2.11+
+
 ## [0.5.0]
 ### Added:
 - Versioning support

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ IMPORTANT: code snippets below should be embedded to `init.lua`, so they would t
   Warning! It's not correct to specify 'bucket_id' as a 'key' parameter for register_sharding_key().
   The 'bucket_id' field is a place where the output of sharding function is saved to.
 
+* Before 0.6.0, each storage migration run time was limited to 3600 seconds (#66).
+  If your migrations run longer than this limit, it will result in timeout error.
+
+  Starting with 0.6.0, you may configure this value with clusterwide config to
+  allow longer migrations. Default is 3600 seconds.
+  ```yaml
+  migrations:
+    options:
+      storage_timeout: 43200 # in seconds
+  ```
+
 ## Limitations
 - all migrations will be run on all cluster nodes (no partial migrations);
 - no pre-validation for migrations code (yet), so you should test them beforehands;

--- a/README.md
+++ b/README.md
@@ -121,33 +121,32 @@ IMPORTANT: code snippets below should be embedded to `init.lua`, so they would t
 
 ## Utils, helpers, tips and tricks
 * Specify a sharding key for `cartridge.ddl` (if you use it) using `utils.register_sharding_key`:
-```lua
-    up = function()
-        local utils = require('migrator.utils')
-        local f = box.schema.create_space('my_sharded_space', {
-            format = {
-                { name = 'key', type = 'string' },
-                { name = 'bucket_id', type = 'unsigned' },
-                { name = 'value', type = 'any', is_nullable = true }
-            },
-            if_not_exists = true,
-        })
-        f:create_index('primary', {
-            parts = { 'key' },
-            if_not_exists = true,
-        })
-        f:create_index('bucket_id', {
-            parts = { 'bucket_id' },
-            if_not_exists = true,
-            unique = false
-        })
-        utils.register_sharding_key('my_sharded_space', {'key'})
-        return true
-    end
-```
-Warning! It's not correct to specify 'bucket_id' as a 'key' parameter for register_sharding_key().
-The 'bucket_id' field is a place where the output of sharding function is saved to.
-
+  ```lua
+      up = function()
+          local utils = require('migrator.utils')
+          local f = box.schema.create_space('my_sharded_space', {
+              format = {
+                  { name = 'key', type = 'string' },
+                  { name = 'bucket_id', type = 'unsigned' },
+                  { name = 'value', type = 'any', is_nullable = true }
+              },
+              if_not_exists = true,
+          })
+          f:create_index('primary', {
+              parts = { 'key' },
+              if_not_exists = true,
+          })
+          f:create_index('bucket_id', {
+              parts = { 'bucket_id' },
+              if_not_exists = true,
+              unique = false
+          })
+          utils.register_sharding_key('my_sharded_space', {'key'})
+          return true
+      end
+  ```
+  Warning! It's not correct to specify 'bucket_id' as a 'key' parameter for register_sharding_key().
+  The 'bucket_id' field is a place where the output of sharding function is saved to.
 
 ## Limitations
 - all migrations will be run on all cluster nodes (no partial migrations);

--- a/migrator/version.lua
+++ b/migrator/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.5.0'
+return '0.6.0'

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -85,7 +85,7 @@ for k, configure_func in pairs(cases) do
         end
 
         -- gh-26 - check that httpd is disabled on some nodes
-        t.assert_equals(
+        t.assert_covers(
             g.cluster:server('storage-2-2'):http_request('get', '/', {raise = false}),
             {status = 595, reason = "Couldn't connect to server"}
         )

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -94,7 +94,7 @@ for k, configure_func in pairs(cases) do
         local result = main:http_request('post', '/migrations/up', { json = {} })
         for _, server in pairs(g.cluster.servers) do
             -- spaces may be created with a slight delay on replicas
-            g.cluster:retrying({ timeout = 1 }, function()
+            g.cluster:retrying({ timeout = 5 }, function()
                 t.assert_not(server.net_box:eval('return box.space.first == nil'), server.alias)
             end)
         end

--- a/test/integration/console_run_test.lua
+++ b/test/integration/console_run_test.lua
@@ -85,7 +85,7 @@ for k, configure_func in pairs(cases) do
         end
         local result = g.cluster.main_server.net_box:eval('return require("migrator").up()')
         t.assert_equals(result, { "01_first.lua", "02_second.lua", "03_sharded.lua" })
-        g.cluster:retrying({ timeout = 1 }, function()
+        g.cluster:retrying({ timeout = 5 }, function()
             for _, server in pairs(g.cluster.servers) do
                 t.assert_not(server.net_box:eval('return box.space.first == nil'))
             end

--- a/test/integration/fockups_test.lua
+++ b/test/integration/fockups_test.lua
@@ -123,13 +123,11 @@ g.test_error_in_migrations = function()
             end
         }
     ]] } })
-    local result = g.cluster.main_server:http_request('post', '/migrations/up', { json = {}, raise = false })
-    t.assert_equals(result.status, 500)
 
-    t.xfail('See https://github.com/tarantool/migrations/issues/63')
-
-    t.assert_str_contains(result.body, 'Oops')
-    t.assert_str_contains(result.body, 'Errors happened during migrations')
+    local status, resp = g.cluster.main_server:eval("return pcall(function() require('migrator').up() end)")
+    t.assert_equals(status, false)
+    t.assert_str_contains(tostring(resp), 'Oops')
+    t.assert_str_contains(tostring(resp), 'Errors happened during migrations')
 end
 
 g.test_inconsistent_migrations = function()
@@ -153,12 +151,9 @@ g.test_inconsistent_migrations = function()
                 })
             ]])
 
-    local result = g.cluster.main_server:http_request('post', '/migrations/up', { json = {}, raise = false })
-    t.assert_equals(result.status, 500)
-
-    t.xfail('See https://github.com/tarantool/migrations/issues/63')
-
-    t.assert_str_contains(result.body, 'Not all migrations applied')
+    local status, resp = g.cluster.main_server:eval("return pcall(function() require('migrator').up() end)")
+    t.assert_equals(status, false)
+    t.assert_str_contains(tostring(resp), 'Not all migrations applied')
 end
 
 g.test_reload = function()

--- a/test/integration/migrations-gh-66/01_first.lua
+++ b/test/integration/migrations-gh-66/01_first.lua
@@ -1,0 +1,7 @@
+return {
+    up = function()
+        local fiber = require('fiber')
+        fiber.sleep(5)
+        return true
+    end
+}


### PR DESCRIPTION
This patchset introduces various test fixes, as well as ability to set storage timeout.

Before this patch, storage net.box call for migration evaluation was strictly limited to 3600 seconds with a comment "timeout should be disabled ... [since] migrations might take long time". But there are users who prefer migrations slower than one hour to reduce the load on production cluster, and such approach is impossible with current hardcoded timeout implementation. After this patch, one will be able to set up call timeout with clusterwide configuration section.

```yaml
migrations:
  options:
    storage_timeout: 43200 # in seconds
```

Since default is 3600 seconds either way, this change should not affect existing users.

Closes #63
Closes #66