### PR TITLE
[68] added utils.check_roles_enabled helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Added `utils.check_roles_enabled` helper function
+  to check whether roles are enabled on the instance (gh-68)
+
 ## [0.6.0]
 ### Added:
 - Configurable timeout for storage migrations (gh-66)

--- a/migrator/utils.lua
+++ b/migrator/utils.lua
@@ -52,9 +52,27 @@ local function register_sharding_key(space_name, key)
     box.space._ddl_sharding_key:replace{space_name, key}
 end
 
+
+-- Check whether expected cartridge roles are enabled on a server.
+--- @param roles_list table array of role names
+---
+local function check_roles_enabled(roles_list)
+    local topology = require('cartridge.confapplier').get_readonly('topology')
+    local cur_roles = topology.replicasets[box.info.cluster.uuid].roles
+
+    for _, rname in pairs(roles_list) do
+        if cur_roles[rname] == nil then
+            return false
+        end
+    end
+
+    return true
+end
+
 return {
     value_in = value_in,
     compare = compare,
 
-    register_sharding_key = register_sharding_key
+    register_sharding_key = register_sharding_key,
+    check_roles_enabled = check_roles_enabled,
 }

--- a/test/entrypoint/check_roles_enabled_init.lua
+++ b/test/entrypoint/check_roles_enabled_init.lua
@@ -1,0 +1,42 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+
+package.preload['cartridge.roles.role1-dep'] = function()
+    return {
+        role_name = 'cartridge.roles.role1-dep',
+    }
+end
+
+package.preload['cartridge.roles.role1'] = function()
+    return {
+        role_name = 'cartridge.roles.role1',
+        dependencies = {'cartridge.roles.role1-dep'},
+    }
+end
+
+package.preload['cartridge.roles.role2'] = function()
+    return {
+        role_name = 'cartridge.roles.role2',
+    }
+end
+
+local cartridge = require('cartridge')
+local ok, err = cartridge.cfg({
+    workdir = 'tmp/db',
+    roles = {
+        'cartridge.roles.role1-dep',
+        'cartridge.roles.role1',
+        'cartridge.roles.role2',
+        'cartridge.roles.vshard-storage',
+        'cartridge.roles.vshard-router',
+        'migrator',
+    },
+    cluster_cookie = 'secret-cluster-cookie',
+}, {
+    log_level = 5
+})
+
+require('migrator').set_loader(require('migrator.directory-loader').new('test/integration/migrations_check_roles_enabled'))
+
+assert(ok, tostring(err))

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -21,6 +21,7 @@ helper.server_command = fio.pathjoin(helper.root, 'test', 'init.lua')
 t.before_suite(function()
     fio.rmtree(helper.datadir)
     fio.mktree(helper.datadir)
+    box.cfg{}
 end)
 
 return helper

--- a/test/integration/check_roles_enabled_test.lua
+++ b/test/integration/check_roles_enabled_test.lua
@@ -1,0 +1,116 @@
+local t = require('luatest')
+local g = t.group('check_roles_enabled_integration')
+local fiber = require('fiber') -- luacheck: ignore
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+
+local shared = require('test.helper.integration').shared
+
+local datadir = fio.pathjoin(shared.datadir, 'basic')
+
+g.cluster = cartridge_helpers.Cluster:new({
+    server_command = fio.pathjoin(shared.root, 'test', 'entrypoint', 'check_roles_enabled_init.lua'),
+    datadir = datadir,
+    use_vshard = true,
+    base_advertise_port = 10400,
+    base_http_port = 10090,
+    replicasets = {
+        {
+            alias = 'api',
+            uuid = cartridge_helpers.uuid('a'),
+            roles = { 'vshard-router', 'migrator' },
+            servers = { { alias='api-master', instance_uuid = cartridge_helpers.uuid('a', 1) } },
+        },
+        {
+            alias = 'storage-role1-role2',
+            uuid = cartridge_helpers.uuid('b'),
+            roles = { 'vshard-storage', 'cartridge.roles.role1', 'cartridge.roles.role2', 'migrator' },
+            servers = {
+                {
+                    alias = 'storage-role1-role2-master',
+                    instance_uuid = cartridge_helpers.uuid('b', 1),
+                    env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                },
+                {
+                    alias = 'storage-role1-role2-replica',
+                    instance_uuid = cartridge_helpers.uuid('b', 2),
+                    env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                },
+            },
+        },
+    },
+})
+
+g.before_all(function(cg) cg.cluster:start() end)
+g.after_all(function(cg) cg.cluster:stop() end)
+
+g.test_check = function(cg)
+    t.assert(cg.cluster:server('api-master'):exec(function() return require('migrator.utils').check_roles_enabled({'vshard-router'}) end))
+    t.assert(cg.cluster:server('api-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-router', 'migrator'})
+    end))
+    t.assert(cg.cluster:server('api-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-router', 'migrator', 'ddl-manager'})
+    end))
+    t.assert_not(cg.cluster:server('api-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-storage', 'migrator', 'ddl-manager'})
+    end))
+
+    t.assert(cg.cluster:server('storage-role1-role2-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-storage'})
+    end))
+
+    t.assert(cg.cluster:server('storage-role1-role2-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled(
+            {'vshard-storage', 'migrator', 'ddl-manager', 'cartridge.roles.role1', 'cartridge.roles.role2', 'cartridge.roles.role1-dep'}
+        )
+    end))
+
+    t.assert_not(cg.cluster:server('storage-role1-role2-master'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-router', 'migrator', 'cartridge.roles.role1-dep'})
+    end))
+
+    t.assert(cg.cluster:server('storage-role1-role2-replica'):exec(function()
+        return require('migrator.utils').check_roles_enabled({'vshard-storage'})
+    end))
+
+    t.assert(cg.cluster:server('storage-role1-role2-replica'):exec(function()
+        return require('migrator.utils').check_roles_enabled(
+            {'vshard-storage', 'migrator', 'ddl-manager', 'cartridge.roles.role1', 'cartridge.roles.role2', 'cartridge.roles.role1-dep'}
+        )
+    end))
+
+    t.assert_not(cg.cluster:server('storage-role1-role2-replica'):exec(function()
+        return require('migrator.utils').check_roles_enabled(
+            {'vshard-router', 'migrator', 'cartridge.roles.role1-dep'}
+        )
+    end))
+end
+
+g.test_with_migrations = function (cg)
+    local status, resp = cg.cluster.main_server:exec(function() return pcall(function() require('migrator').up() end) end)
+    t.assert_equals(status, true, resp)
+
+    t.assert(cg.cluster:server('api-master'):exec(function()
+        return rawget(_G, 'vshard-router-set') or false
+    end))
+    t.assert_not(cg.cluster:server('api-master'):exec(function()
+        return rawget(_G, 'vshard-storage-set') or false
+    end))
+
+    t.assert_not(cg.cluster:server('storage-role1-role2-master'):exec(function()
+        return rawget(_G, 'vshard-router-set') or false
+    end))
+    t.assert(cg.cluster:server('storage-role1-role2-master'):exec(function()
+        return rawget(_G, 'vshard-storage-set') or false
+    end))
+
+    t.assert_not(cg.cluster:server('storage-role1-role2-replica'):exec(function()
+        return rawget(_G, 'vshard-router-set') or false
+    end))
+    t.assert_not(cg.cluster:server('storage-role1-role2-replica'):exec(function()
+        return rawget(_G, 'vshard-storage-set') or false
+    end))
+end

--- a/test/integration/migrations_check_roles_enabled/01_first.lua
+++ b/test/integration/migrations_check_roles_enabled/01_first.lua
@@ -1,0 +1,14 @@
+local utils = require('migrator.utils')
+
+return {
+    up = function()
+        if utils.check_roles_enabled({'vshard-router'}) then
+            rawset(_G, 'vshard-router-set', true)
+        end
+
+        if utils.check_roles_enabled({'vshard-storage'}) then
+            rawset(_G, 'vshard-storage-set', true)
+        end
+        return true
+    end
+}

--- a/test/unit/check_roles_enabled_test.lua
+++ b/test/unit/check_roles_enabled_test.lua
@@ -1,0 +1,39 @@
+local t = require("luatest")
+local g = t.group("check_roles_enabled_unit")
+
+g.before_all(function(cg)
+    cg._orig_confapplier = package.loaded["cartridge.confapplier"]
+end)
+
+g.after_all(function(cg)
+    package.loaded["cartridge.confapplier"] = cg._orig_confapplier
+end)
+
+g.test_check = function()
+    package.loaded["cartridge.confapplier"] = {
+        get_readonly = function()
+            return {
+                replicasets = {
+                    [box.info.cluster.uuid] = {
+                        roles = {
+                            ['space-explorer'] = true,
+                            ['vshard-router'] = true,
+                            ['crud-router'] = true,
+                            ['my_super_role'] = true,
+                        }
+                    }
+                }
+            }
+        end
+    }
+
+    local utils = require('migrator.utils')
+
+    t.assert(utils.check_roles_enabled({'crud-router', 'my_super_role'}))
+    t.assert(utils.check_roles_enabled({'space-explorer', 'vshard-router', 'crud-router', 'my_super_role'}))
+    t.assert(utils.check_roles_enabled({}))
+    t.assert(utils.check_roles_enabled({'my_super_role'}))
+    t.assert_not(utils.check_roles_enabled({'crud-storage', 'my_super_role'}))
+    t.assert_not(utils.check_roles_enabled({'crud-storage'}))
+    t.assert_not(utils.check_roles_enabled({'crud-storage', 'expirationd'}))
+end


### PR DESCRIPTION
This helper check are provided roles enabled on instance.
It might be very usefull if you want to run migration code only on specific roles.

Closes #68