### PR TITLE
Support migrations in new replicaset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed:
+- Migrations do not apply to newly added replica sets in the cluster (gh-65)
+  Applied migration names are moved from the cluster-wide configuration to
+  the space on each node.
+
 ## [0.7.0]
 ### Added:
 - `utils.check_roles_enabled` helper function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Applied migration names are moved from the cluster-wide configuration to
   the space on each node.
 
+### Added:
+- An API for moving existing migration names from the cluster configuration to
+  a space.
+
 ## [0.7.0]
 ### Added:
 - `utils.check_roles_enabled` helper function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added:
 - An API for moving existing migration names from the cluster configuration to
   a space.
+- API for getting applied migrations list for the cluster.
 
 ## [0.7.0]
 ### Added:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ version := scm-1
 
 .PHONY: all doc test schema install
 
-BUNDLE_VERSION=1.10.11-0-gf0b0e7ecf-r427
+BUNDLE_VERSION=2.8.4-0-g47e6bd362-r508
 COMMIT_TAG = $(shell git describe)
 
 all: doc

--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ IMPORTANT: code snippets below should be embedded to `init.lua`, so they would t
         end
     ```
 
+* To get a list of applied migrations make a GET request to
+  `http://<your_tarantool_ip>:<http_port>/migrations/applied` or call
+  `require('migrator').get_applied()` on any cluster instance. This method will return a list of
+  applied migrations grouped by a leader node.
+
 ## Upgrade from 0.* versions.
 
 Applied migrations names storage method has been changed in `1.*` version: applied migrations list

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Every migration (e. g. `0001_create_my_sharded_space_DATETIME.lua`) should expos
 5) What will happen then:
     * coordinator node (the one you curled upon) will trigger migrations execution on all replicaset leaders;
     * each replicaset leader will apply all available migrations and reply to coordinator;
-    * if all replies are successful, coordinator will apply changes to cluster-wide config - a list of applied migrations and (optionally) resulting ddl-schema.
+    * each replicaset leader stores a list of applied migrations in a space;
+    * if all replies are successful, coordinator will apply changes to the resulting cluster ddl-schema.
 
 6) That's it!
 

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -99,16 +99,34 @@ for k, configure_func in pairs(cases) do
             end)
         end
 
-        local expected_applied = { "01_first.lua", "02_second.lua", "03_sharded.lua" }
+        local expected_applied = {
+            ["api-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"},
+            ["storage-1-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"},
+            ["storage-2-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"},
+        }
         t.assert_equals(result.json, { applied = expected_applied })
 
         local config = main:download_config()
         t.assert_covers(config, {
-            migrations = { applied = expected_applied }
-        })
-        t.assert_covers(config, {
             schema = {
                 spaces = {
+                    _migrations = {
+                        engine = "memtx",
+                        format = {
+                            {is_nullable = false, name = "id", type = "unsigned"},
+                            {is_nullable = false, name = "name", type = "string"}
+                        },
+                        indexes = {
+                            {
+                                name = "primary",
+                                parts = {{is_nullable = false, path = "id", type = "unsigned"}},
+                                type = "TREE",
+                                unique = true,
+                            },
+                        },
+                        is_local = false,
+                        temporary = false,
+                    },
                     first = {
                         engine = "memtx",
                         format = {

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -45,6 +45,7 @@ g.cluster = cartridge_helpers.Cluster:new({
 
 g.before_all(function() g.cluster:start() end)
 g.after_all(function() g.cluster:stop() end)
+g.after_each(function() utils.cleanup(g) end)
 
 local cases = {
     with_config_loader = function()
@@ -77,7 +78,6 @@ local cases = {
 
 for k, configure_func in pairs(cases) do
     g['test_basic_' .. k] = function()
-        utils.cleanup(g)
         configure_func()
 
         for _, server in pairs(g.cluster.servers) do
@@ -168,8 +168,6 @@ for k, configure_func in pairs(cases) do
 end
 
 g.test_gh_66_configurable_timeout = function(cg)
-    utils.cleanup(cg)
-
     local main = g.cluster.main_server
 
     main:eval([[

--- a/test/integration/console_run_test.lua
+++ b/test/integration/console_run_test.lua
@@ -45,6 +45,7 @@ g.cluster = cartridge_helpers.Cluster:new({
 
 g.before_all(function() g.cluster:start() end)
 g.after_all(function() g.cluster:stop() end)
+g.after_each(function() utils.cleanup(g) end)
 
 local cases = {
     with_config_loader = function()
@@ -77,7 +78,6 @@ local cases = {
 
 for k, configure_func in pairs(cases) do
     g['test_run_from_console_' .. k] = function()
-        utils.cleanup(g)
         configure_func()
 
         for _, server in pairs(g.cluster.servers) do

--- a/test/integration/console_run_test.lua
+++ b/test/integration/console_run_test.lua
@@ -84,7 +84,11 @@ for k, configure_func in pairs(cases) do
             t.assert(server.net_box:eval('return box.space.first == nil'), server.alias)
         end
         local result = g.cluster.main_server.net_box:eval('return require("migrator").up()')
-        t.assert_equals(result, { "01_first.lua", "02_second.lua", "03_sharded.lua" })
+        t.assert_equals(result, {
+            ["api-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"},
+            ["storage-1-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"},
+            ["storage-2-1"] = {"01_first.lua", "02_second.lua", "03_sharded.lua"}
+        })
         g.cluster:retrying({ timeout = 5 }, function()
             for _, server in pairs(g.cluster.servers) do
                 t.assert_not(server.net_box:eval('return box.space.first == nil'))

--- a/test/integration/get_applied_test.lua
+++ b/test/integration/get_applied_test.lua
@@ -1,0 +1,101 @@
+local t = require('luatest')
+local g = t.group('get_migrations_state')
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+local shared = require('test.helper.integration').shared
+local utils = require("test.helper.utils")
+local datadir = fio.pathjoin(shared.datadir, 'get_migrations_state')
+
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = true,
+        base_advertise_port = 10500,
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router', 'migrator' },
+                servers = { {
+                    alias = 'router',
+                    instance_uuid = cartridge_helpers.uuid('a', 1)
+                } },
+            },
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage', 'migrator' },
+                servers = {
+                    {
+                        alias = 'storage-1-master',
+                        instance_uuid = cartridge_helpers.uuid('b', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-1-replica',
+                        instance_uuid = cartridge_helpers.uuid('b', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                },
+            },
+            {
+                alias = 'storage-2',
+                uuid = cartridge_helpers.uuid('c'),
+                roles = { 'vshard-storage', 'migrator' },
+                servers = {
+                    {
+                        alias = 'storage-2-master',
+                        instance_uuid = cartridge_helpers.uuid('c', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-2-replica',
+                        instance_uuid = cartridge_helpers.uuid('c', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                },
+            },
+        },
+    })
+
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+g.after_each(function() utils.cleanup(g) end)
+
+g.test_get_migrations_state = function(cg)
+    local main = cg.cluster.main_server
+
+    local status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ['router'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-1-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-2-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+    })
+
+    status, resp = main:eval("return pcall(require('migrator').get_applied)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ['router'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-1-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-2-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+    })
+
+    -- Check the same result is returned by http.
+    local result = main:http_request('get', '/migrations/applied')
+    local expected_applied = {
+        ['router'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-1-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-2-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+    }
+    t.assert_equals(result.json, { applied = expected_applied })
+end

--- a/test/integration/migrations-gh-65/001_create_func.lua
+++ b/test/integration/migrations-gh-65/001_create_func.lua
@@ -1,0 +1,8 @@
+return {
+    up = function()
+        box.schema.func.create('sum', {
+            body = [[ function(a, b) return a + b end ]]
+        })
+        return true
+    end
+}

--- a/test/integration/move_migrations_state_test.lua
+++ b/test/integration/move_migrations_state_test.lua
@@ -1,0 +1,295 @@
+local t = require('luatest')
+local g = t.group('move_migrations_state')
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+local shared = require('test.helper.integration').shared
+local utils = require("test.helper.utils")
+local datadir = fio.pathjoin(shared.datadir, 'move_migrations_state')
+
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = true,
+        base_advertise_port = 10600,
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router', 'migrator' },
+                servers = { {
+                    alias = 'router',
+                    instance_uuid = cartridge_helpers.uuid('a', 1)
+                } },
+            },
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage', 'migrator' },
+                servers = {
+                    {
+                        alias = 'storage-1-master',
+                        instance_uuid = cartridge_helpers.uuid('b', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-1-replica',
+                        instance_uuid = cartridge_helpers.uuid('b', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                },
+            },
+            {
+                alias = 'storage-2',
+                uuid = cartridge_helpers.uuid('c'),
+                roles = { 'vshard-storage', 'migrator' },
+                servers = {
+                    {
+                        alias = 'storage-2-master',
+                        instance_uuid = cartridge_helpers.uuid('c', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-2-replica',
+                        instance_uuid = cartridge_helpers.uuid('c', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                },
+            },
+        },
+    })
+
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+g.after_each(function() utils.cleanup(g) end)
+
+g.test_move_migrations_state = function(cg)
+    local main = cg.cluster.main_server
+
+    -- Pretend first two migrations are already applied on cluster by prev migrator version.
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {
+                applied = { '01_first.lua', '02_second.lua' }
+            }
+        })
+    ]])
+
+    -- `up` call does not work due to non-empty cluster-wide migrations list.
+    local status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert_not(status)
+    t.assert_str_contains(tostring(resp), 'Cannot perform an upgrade.')
+
+    -- Move migrations.
+    status, resp = main:eval("return pcall(require('migrator').move_migrations_state)")
+    t.assert(status, tostring(resp))
+    t.assert_items_equals(resp, {
+        ["router"] = {"01_first.lua", "02_second.lua"},
+        ["storage-1-master"] = {"01_first.lua", "02_second.lua"},
+        ["storage-2-master"] = {"01_first.lua", "02_second.lua"},
+    })
+
+    -- Check migrations are copied.
+    for _, server_alias in pairs({'router', 'storage-1-master', 'storage-2-master'}) do
+        t.assert(cg.cluster:server(server_alias):eval([[
+            return box.space._migrations:get(1)['name'] == '01_first.lua' and
+                box.space._migrations:get(2)['name'] == '02_second.lua'
+        ]]))
+    end
+    t.assert(main:eval([[
+        return require('cartridge.confapplier').get_readonly('migrations').applied == nil
+    ]]))
+
+    -- `up` should perform 03 migration only.
+    status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ['router'] = { '03_sharded.lua' },
+        ['storage-1-master'] = { '03_sharded.lua' },
+        ['storage-2-master'] = { '03_sharded.lua' },
+    })
+end
+
+g.test_move_migrations_state_http = function(cg)
+    local main = cg.cluster.main_server
+
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {
+                applied = { '01_first.lua', '02_second.lua' }
+            }
+        })
+    ]])
+
+    -- Move migrations.
+    local result = main:http_request('post', '/migrations/move_migrations_state', { json = {} })
+    local expected_moved = {
+        ['router'] = { '01_first.lua', '02_second.lua' },
+        ['storage-1-master'] = { '01_first.lua', '02_second.lua' },
+        ['storage-2-master'] = { '01_first.lua', '02_second.lua' },
+    }
+    t.assert_equals(result.json, { migrations_moved = expected_moved })
+
+    -- Check migrations are copied.
+    for _, server_alias in pairs({'router', 'storage-1-master', 'storage-2-master'}) do
+        t.assert(cg.cluster:server(server_alias):eval([[
+            return box.space._migrations:get(1)['name'] == '01_first.lua' and
+                box.space._migrations:get(2)['name'] == '02_second.lua'
+        ]]))
+    end
+end
+
+g.test_move_migrations_call_on_replica = function(cg)
+    local main = cg.cluster.main_server
+
+    -- Pretend first two migrations are already applied on cluster by prev migrator version.
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {
+                applied = { '01_first.lua', '02_second.lua' }
+            }
+        })
+    ]])
+
+    -- Move migrations.
+    local status, resp = cg.cluster:server('storage-1-replica'):eval(
+        "return pcall(require('migrator').move_migrations_state)")
+    t.assert(status, tostring(resp))
+    t.assert_items_equals(resp, {
+        ["router"] = {"01_first.lua", "02_second.lua"},
+        ["storage-1-master"] = {"01_first.lua", "02_second.lua"},
+        ["storage-2-master"] = {"01_first.lua", "02_second.lua"},
+    })
+
+    -- Check migrations are copied.
+    for _, server_alias in pairs({'router', 'storage-1-master', 'storage-2-master'}) do
+        t.assert(cg.cluster:server(server_alias):eval([[
+            return box.space._migrations:get(1)['name'] == '01_first.lua' and
+                box.space._migrations:get(2)['name'] == '02_second.lua'
+        ]]))
+    end
+    t.assert(main:eval([[
+        return require('cartridge.confapplier').get_readonly('migrations').applied == nil
+    ]]))
+end
+
+g.test_move_empty_migrations_state = function(cg)
+    local main = cg.cluster.main_server
+
+    -- Pretend first two migrations are already applied on custer by prev migrator version.
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {applied = {}},
+            options = {storage_timeout = 3.0}
+        })
+    ]])
+
+    -- Move migrations. No config - no errors.
+    local status, resp = main:eval("return pcall(require('migrator').move_migrations_state)")
+    t.assert(status, tostring(resp))
+    t.assert_items_equals(resp, {})
+end
+
+g.test_move_migrations_consistency_check = function(cg)
+    local main = cg.cluster.main_server
+
+    local status, resp = main:eval([[
+        return pcall(require('cartridge').config_patch_clusterwide,
+            {migrations = {applied = {}}})
+    ]])
+    t.assert(status, tostring(resp))
+
+    -- Apply all migrations.
+    status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ['router'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-1-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+        ['storage-2-master'] = { '01_first.lua', '02_second.lua', '03_sharded.lua' },
+    })
+
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {applied = { '01_first.lua', '02_second.lua', '03_sharded.lua' }},
+        })
+    ]])
+
+    -- Migrations in config are consistent with local. No error.
+    status, resp = main:eval("return pcall(require('migrator').move_migrations_state)")
+    t.assert(status, tostring(resp))
+    t.assert_items_equals(resp, {
+        ['router'] = {},
+        ['storage-1-master'] = {},
+        ['storage-2-master'] = {},
+    })
+
+    -- Make state inconsistent.
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {applied = { '01_first.lua', '03_sharded.lua' }}
+        })
+    ]])
+    status, resp = main:eval("return pcall(require('migrator').move_migrations_state)")
+    t.assert_not(status)
+    t.assert_str_contains(tostring(resp), 'Inconsistency between cluster-wide and local applied migrations')
+
+    -- Make sure cluster-wide migrations state is still there.
+    t.assert(main:eval([[
+        return require('cartridge.confapplier').get_readonly('migrations').applied ~= nil
+    ]]))
+end
+
+g.test_move_migrations_append_to_existing_local = function(cg)
+    local main = cg.cluster.main_server
+
+    for _, server in pairs(cg.cluster.servers) do
+        server:eval([[
+            require('migrator').set_loader({
+                list = function()
+                    return {
+                        {
+                            name = '01.lua',
+                            up = function() return true end
+                        },
+                    }
+                end
+            })
+        ]])
+    end
+
+    local status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ['router'] = { '01.lua' },
+        ['storage-1-master'] = { '01.lua' },
+        ['storage-2-master'] = { '01.lua' },
+    })
+
+    -- Append "applied" migrations to cluster config.
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {applied = { '01.lua', '02.lua' }},
+        })
+    ]])
+
+    -- Only new missing applied migrations is copied to local storage.
+    status, resp = main:eval("return pcall(require('migrator').move_migrations_state)")
+    t.assert(status, tostring(resp))
+    t.assert_items_equals(resp, {
+        ['router'] = { '02.lua' },
+        ['storage-1-master'] = { '02.lua' },
+        ['storage-2-master'] = { '02.lua' },
+    })
+
+    t.assert(main:eval([[
+        return require('cartridge.confapplier').get_readonly('migrations').applied == nil
+    ]]))
+end

--- a/test/integration/new_replicaset_test.lua
+++ b/test/integration/new_replicaset_test.lua
@@ -1,0 +1,121 @@
+local t = require('luatest')
+local g = t.group('join_new_instance')
+local fiber = require('fiber') -- luacheck: ignore
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+local shared = require('test.helper.integration').shared
+local datadir = fio.pathjoin(shared.datadir, 'join_new_server')
+local utils = require("test.helper.utils")
+
+
+
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = true,
+        base_advertise_port = 10700,
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router' },
+                servers = { {
+                    alias = 'router',
+                    instance_uuid = cartridge_helpers.uuid('a', 1)
+                } },
+            },
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage' },
+                servers = {
+                    {
+                        alias = 'storage-1-master',
+                        instance_uuid = cartridge_helpers.uuid('b', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-1-replica',
+                        instance_uuid = cartridge_helpers.uuid('b', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                },
+            },
+        },
+    })
+
+    g.new_server = cartridge_helpers.Server:new({
+        alias = 'storage-2-master',
+        command = g.cluster.server_command,
+        replicaset_uuid = cartridge_helpers.uuid('c'),
+        instance_uuid = cartridge_helpers.uuid('c', 1),
+        cluster_cookie = g.cluster.cookie,
+        workdir = datadir,
+        advertise_port = 10204,
+        http_port = 8084,
+    })
+
+    g.cluster:start()
+    g.new_server:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    g.new_server:stop()
+    fio.rmtree(g.cluster.datadir)
+    fio.rmtree(g.new_server.workdir)
+end)
+
+g.after_each(function() utils.cleanup(g) end)
+
+g.test_gh_65_migrations_in_new_replicaset = function(cg)
+    local main = cg.cluster.main_server
+
+    main:eval([[
+        require('cartridge').config_patch_clusterwide({migrations = {options = {storage_timeout = 3.0}}})
+    ]])
+
+    local set_loader = [[
+        require('migrator').set_loader(
+            require('migrator.directory-loader').new('test/integration/migrations-gh-65')
+        )
+    ]]
+
+    for _, server in pairs(cg.cluster.servers) do
+        server.net_box:eval(set_loader)
+    end
+
+    local status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ["router"] = {"001_create_func.lua"},
+        ["storage-1-master"] = {"001_create_func.lua"},
+    })
+
+    t.assert(cg.cluster:server('router'):eval([[ return box.func.sum ~= nil ]]))
+    t.assert(cg.cluster:server('storage-1-master'):eval([[ return box.func.sum ~= nil ]]))
+    t.assert(cg.cluster:server('storage-1-replica'):eval([[ return box.func.sum ~= nil ]]))
+
+    cg.new_server:eval(set_loader)
+    cg.new_server:join_cluster(main)
+    cg.cluster:wait_until_healthy()
+
+    -- Wait until new member really become healthy.
+    cg.cluster:retrying({ timeout = 5 }, function()
+        t.assert(main:eval([[
+            local member = require('membership').get_member('localhost:10204')
+            return member and member.payload.state_prev == 'ConfiguringRoles' or
+                member.payload.state_prev == 'RolesConfigured'
+        ]]))
+    end)
+
+    status, resp = main:eval("return pcall(require('migrator').up)")
+    t.assert(status, tostring(resp))
+    t.assert_equals(resp, {
+        ["storage-2-master"] = {"001_create_func.lua"},
+    })
+    t.assert(cg.new_server:eval([[ return box.func.sum ~= nil ]]))
+end

--- a/test/integration/no_cartridge_ddl_test.lua
+++ b/test/integration/no_cartridge_ddl_test.lua
@@ -41,6 +41,7 @@ g.before_all(function()
     end
 end)
 g.after_all(function() g.cluster:stop() end)
+g.after_each(function() utils.cleanup(g) end)
 
 local cases = {
     with_config_loader = function()
@@ -73,7 +74,6 @@ local cases = {
 
 for k, configure_func in pairs(cases) do
     g['test_no_cartridge_ddl_' .. k] = function()
-        utils.cleanup(g)
         configure_func()
 
         local main = g.cluster.main_server

--- a/test/integration/upgrade_test.lua
+++ b/test/integration/upgrade_test.lua
@@ -1,0 +1,109 @@
+local t = require('luatest')
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+local shared = require('test.helper.integration').shared
+local utils = require("test.helper.utils")
+
+local g = t.group('upgrade')
+
+local datadir = fio.pathjoin(shared.datadir, 'upgrade')
+
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = false,
+        base_advertise_port = 13400,
+        base_http_port = 8090,
+        replicasets = {
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'migrator' },
+                servers = { { instance_uuid = cartridge_helpers.uuid('a', 1) } },
+            },
+        },
+    })
+
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+g.after_each(function() utils.cleanup(g) end)
+
+g.test_upgrade_basic = function(cg)
+    local main = cg.cluster.main_server
+    main:eval([[
+        require('migrator').set_loader(
+            require('migrator.config-loader').new())
+    ]])
+    utils.set_sections(g, {
+        {
+            filename = "migrations/source/01_script.lua",
+            content = [[
+                return {
+                    up = function()
+                        box.schema.create_space('test', {
+                            format = {{'id', type='unsigned'}},
+                        })
+                        box.space.test:create_index('p')
+                    end
+                }
+            ]]
+        },
+        {
+            filename = "migrations/source/02_script.lua",
+            content = [[
+                return {
+                    up = function()
+                        box.space.test:insert{1}
+                    end
+                }
+            ]]
+        },
+    })
+
+
+    local result = main:eval([[ return require('migrator').upgrade() ]])
+    t.assert_equals(result.applied_now, {'01_script.lua', '02_script.lua'})
+    t.assert_equals(result.applied, {'01_script.lua', '02_script.lua'})
+
+    t.assert(main:eval([[ return box.space.test:get(1) ]]))
+    t.assert_not(main:eval([[ return box.space.test:get(2) ]]))
+
+    -- Append migration script.
+    utils.set_sections(g, {
+        {
+            filename = "migrations/source/03_script.lua",
+            content = [[ return { up = function() box.space.test:insert{2} end } ]]
+        },
+    })
+    result = main:eval([[ return require('migrator').upgrade() ]])
+    t.assert_equals(result.applied_now, { '03_script.lua' })
+    t.assert_equals(result.applied, { '01_script.lua', '02_script.lua', '03_script.lua' })
+    t.assert(main:eval([[ return box.space.test:get(1) ]]))
+    t.assert(main:eval([[ return box.space.test:get(2) ]]))
+end
+
+g.test_upgrade_clusterwide_applied_migrations_exist = function(cg)
+    local main = cg.cluster.main_server
+    -- Simulate previous version configuration.
+    local _, err = main:eval([[
+        require('cartridge').config_patch_clusterwide({
+            migrations = {
+                applied = { '001.lua', '002.lua' }
+            }
+        })
+    ]])
+    t.assert_not(err)
+
+    local status, resp = main:eval([[ return pcall(require('migrator').upgrade) ]])
+    t.assert_not(status)
+    t.assert_str_contains(tostring(resp), 'A list of applied migrations is found in cluster config')
+end
+


### PR DESCRIPTION
### Fixed:
- Migrations do not apply to newly added replica sets in the cluster (gh-65)
  Applied migration names are moved from the cluster-wide configuration to
  the local space on each node.

### Added:
- API for moving existing migration names storage from cluster config to
  local space.
- API for getting applied migrations list for the cluster.