### PR TITLE
release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0]
 
 ### Fixed:
 - Migrations do not apply to newly added replica sets in the cluster (gh-65)

--- a/migrator/version.lua
+++ b/migrator/version.lua
@@ -1,4 +1,4 @@
--- Сontains the module version.
+-- Contains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.7.0'
+return '1.0.0'


### PR DESCRIPTION
### Overview

This release introduces new approach to storing migration state: per-replicaset instead of clusterwide. New approach fixes the issue when new replicaset did not applied the migrations that are already applied on the remaining part of cluster.

To start using 1.0.0 instead of 0.x.x module on existing application, one must first call `move_migrations_state` through HTTP or Lua API to move current cluster migration state from Cartridge clusterwide configuration to per-replicaset utility spaces. See README.md for upgrade and downgrade scenarios.

### Fixed
- Migrations do not apply to newly added replica sets in the cluster (gh-65). Applied migration names are moved from the cluster-wide configuration to the space on each node.

### Added
- An API for moving existing migration names from the cluster configuration to a space.
- API for getting applied migrations list for the cluster.