### PR TITLE
cartridge: expose operation last error to issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added:
+- Expose last operation error to Cartridge issues (gh-73)
+
 ## [1.0.0]
 
 ### Fixed:

--- a/test/integration/basic_test.lua
+++ b/test/integration/basic_test.lua
@@ -107,7 +107,8 @@ for k, configure_func in pairs(cases) do
         t.assert_equals(result.json, { applied = expected_applied })
 
         local config = main:download_config()
-        t.assert_covers(config, {
+
+        local expected_schema = {
             schema = {
                 spaces = {
                     _migrations = {
@@ -120,6 +121,7 @@ for k, configure_func in pairs(cases) do
                             {
                                 name = "primary",
                                 parts = {{is_nullable = false, path = "id", type = "unsigned"}},
+                                sequence = "_migrations_id_seq",
                                 type = "TREE",
                                 unique = true,
                             },
@@ -175,10 +177,22 @@ for k, configure_func in pairs(cases) do
                         sharding_key = { "key" },
                         temporary = false,
                     },
-
+                },
+                sequences = {
+                    _migrations_id_seq = {
+                        cache = 0,
+                        cycle = false,
+                        max = 9223372036854775807ULL,
+                        min = 1,
+                        start = 1,
+                        step = 1,
+                    },
                 },
             },
-        })
+        }
+
+        expected_schema = utils.downgrade_ddl_schema_if_required(expected_schema)
+        t.assert_covers(config, expected_schema)
 
         result = main:http_request('post', '/migrations/up', { json = {} })
         t.assert_equals(result.json, { applied = {} })


### PR DESCRIPTION
Expose last operation error to Cartridge issues.

![issues](https://github.com/tarantool/migrations/assets/20455996/c7016be4-c777-400f-9456-9bc754f6b565)
(Issues are also exposed to default Grafana dashboard, as well as default alerts.)

![image](https://github.com/tarantool/migrations/assets/20455996/04c1367b-6fde-4aec-8589-cece9e8d5d6d)
(Error message could be improved, but it's always has been like this: I haven't changed anything here in this patch.)

The original issue was about exposing migrations inconsistency from new `migrations` tab to Cartridge issues as well. But using straightforward approach is rather bad: checking inconsistency is a full cluster map-reduce operation, and, if exposed to `get_issues`, it will omit N^2 network requests since issues are collected from each instance, there is no way to check whether migrations are consistent without cluster map-reduce and there is no distinct migrator provider -- any instance is migration provider. And, since `get_issues` may trigger rather often, having such a feature may make cluster unhealthy (we already had similar things with metrics [1]). Last error is reset on each operation call.

1. https://github.com/tarantool/metrics/pull/243

Closes #73