### PR TITLE
[TDB-521] Исправлена работа модуля после поплечевого обновления

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed:
+- State space bootstrap on cluster rolling upgrade
+
 ## [1.0.1]
 
 ### Added:


### PR DESCRIPTION
Когда происходит обновление по плечам - инстанс всегда стартует ведомым.

Могут быть следующие сценарии:
1. Стояла старая версия модуля 0.7 и его обновили по плечам. Первая процедура как мастера будет - `move_migrations_state`.
2. Это первая утсановка модуля. Но ставили так же поплечевым деплоем. Тогда первая процедура как мастера будет - `up`.
3. Если вдруг ставили или обновляли весь кластер целиком, то первая процедура как мастера будет - `init`.

Closes #77

## См. также:
- https://github.com/tarantool/tarantooldb/issues/521