### PR TITLE
release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.2]
 
 ### Fixed:
-- State space bootstrap on cluster rolling upgrade
+- State space bootstrap on cluster rolling upgrade (gh-77)
 
 ## [1.0.1]
 

--- a/migrator/version.lua
+++ b/migrator/version.lua
@@ -1,4 +1,4 @@
 -- Contains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.0.1'
+return '1.0.2'


### PR DESCRIPTION
### Overview

This release fixes module work for rolling upgrade over existing cluster without state space (migrations 0.x or clean cluster).

### Fixed
- State space bootstrap on cluster rolling upgrade (gh-77)