### PR TITLE
Add a check for user modifications to applied migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- A check for user modifications to applied migrations.
+
 ## [1.0.2]
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ IMPORTANT: code snippets below should be embedded to `init.lua`, so they would t
       storage_timeout: 43200 # in seconds
   ```
 
+* By default, modifying already applied migrations is not permitted.
+    The module will throw an error: "Modifying already applied migrations is not allowed. To enable changes, set the is_applied_migrations_writable option. Keep in mind that already applied migrations will not be reapplied.
+    If you wish to make changes, add new migrations."
+
+    However, if you still need to make changes in applied migrations, you can use the `options.is_applied_migrations_writable`
+    flag by setting it to `true` (by default `false`).
+  ```yaml
+  migrations:
+    options:
+      is_applied_migrations_writable: true
+  ```
+
+* **To "correct" the effects of incorrect migrations, write new ones. Modifying old migrations will not help.**
+
 * To run migrations code on a specific roles use `utils.check_roles_enabled`:
     ```lua
         up = function()

--- a/deps.sh
+++ b/deps.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Test dependencies:
-tarantoolctl rocks install luatest 0.5.7
+tarantoolctl rocks install luatest 1.0.1
 tarantoolctl rocks install luacov 0.13.0
 tarantoolctl rocks install luacheck 0.26.0
 tarantoolctl rocks make migrations-scm-1.rockspec

--- a/migrations-scm-1.rockspec
+++ b/migrations-scm-1.rockspec
@@ -9,7 +9,7 @@ dependencies = {
     'tarantool',
     'lua >= 5.1',
     'checks >= 3.0.1-1, <4.0.0',
-    'cartridge >= 2.0.1-1, <3.0.0',
+    'cartridge >= 2.12.1-1, <3.0.0',
 }
 build = {
     type = 'make',
@@ -21,6 +21,7 @@ build = {
             ['migrator.utils'] = 'migrator/utils.lua',
             ['migrator.directory-loader'] = 'migrator/directory-loader.lua',
             ['migrator.config-loader'] = 'migrator/config-loader.lua',
+            ['migrator.changing-applied-migrations'] = 'migrator/changing-applied-migrations.lua',
         },
     },
     build_variables = {

--- a/migrator/changing-applied-migrations.lua
+++ b/migrator/changing-applied-migrations.lua
@@ -44,6 +44,10 @@ local function check_migrations(current_hashes_by_name)
 end
 
 function M.is_migration_space_has_hash_field()
+    if box.space._migrations == nil then
+        return false
+    end
+
     return #box.space._migrations:format() > 2
 end
 

--- a/migrator/changing-applied-migrations.lua
+++ b/migrator/changing-applied-migrations.lua
@@ -1,0 +1,101 @@
+-- This module is used to verify that the user does not modify the code of already applied migrations.
+-- To detect changes in the migration code, an MD5 hash of the migration code is used.
+
+local log = require('log')
+local confapplier = require('cartridge.confapplier')
+
+local DEFAULT_IS_APPLIED_MIGRATIONS_WRITABLE = false
+
+local function is_applied_migrations_writable()
+    local config = confapplier.get_readonly('migrations') or {}
+    local options = config['options'] or {}
+    return options.is_applied_migrations_writable or DEFAULT_IS_APPLIED_MIGRATIONS_WRITABLE
+end
+
+local function is_applied_migration_code_changed(applied_hash, current_hash)
+    -- Ideally, there should never be a 'nil', but if it occurs, it's better to ignore it.
+    -- This is mainly for user's convenience and shouldn't critically affect anything else.
+    if current_hash == nil then
+        return false
+    end
+    return applied_hash ~= current_hash
+end
+
+local function check_migrations(current_hashes_by_name)
+    for _, migration in box.space._migrations:pairs() do
+        local current_hash = current_hashes_by_name[migration.name]
+        if is_applied_migration_code_changed(migration.hash, current_hash) then
+            log.error(
+                "Hashes mismatch for applied migration %s, applied %s, current %s",
+                migration.name,
+                migration.hash,
+                current_hash
+            )
+            error(
+                "Modifying already applied migrations is not allowed. " ..
+                "To enable changes, set the is_applied_migrations_writable option. " ..
+                "Keep in mind that already applied migrations will not be reapplied. " ..
+                "If you wish to make changes, add new migrations."
+            )
+        end
+    end
+end
+
+local function check_applied_migrations_not_changed(conf_new)
+    local vars = require('cartridge.vars').new('migrator')
+    local current_hashes_by_name = vars.loader:hashes_by_name(conf_new)
+
+    if not is_applied_migrations_writable() then
+        check_migrations(current_hashes_by_name)
+    end
+end
+
+local function update_applied_migrations_hashes()
+    local vars = require('cartridge.vars').new('migrator')
+    local hashes_by_name = vars.loader:hashes_by_name()
+
+    for _, t in box.space._migrations:pairs() do
+        -- Ideally, there should never be a nil, but if it occurs, it's better to ignore it.
+        -- This is mainly for user's convenience and shouldn't critically affect anything else.
+        if hashes_by_name[t.name] == nil then
+            log.error(
+                "Failed to get hash for migration %s. Check migrations source code. They might be inconsistent.",
+                t.name
+            )
+        else
+            if t.hash ~= box.NULL then
+                log.info("Update hash for migration %s from %s to %s", t.name, t.hash, hashes_by_name[t.name])
+            else
+                log.info("Create hash for migration %s:%s", t.name, hashes_by_name[t.name])
+            end
+            box.space._migrations:update(t.id,{{'=', 'hash',  hashes_by_name[t.name]}})
+        end
+    end
+end
+
+local function create_hashes_for_migrations()
+    local vars = require('cartridge.vars').new('migrator')
+    local hashes_by_name = vars.loader:hashes_by_name()
+    for _, t in box.space._migrations:pairs() do
+        if t.hash == box.NULL then
+            -- Ideally, there should never be a nil, but if it occurs, it's better to ignore it.
+            -- This is mainly for user's convenience and shouldn't critically affect anything else.
+            if hashes_by_name[t.name] == nil then
+                log.error(
+                    "Failed to get hash for migration %s. Check migrations source code. They might be inconsistent.",
+                    t.name
+                )
+            else
+                box.space._migrations:update(t.id,{{'=', 'hash',  hashes_by_name[t.name]}})
+                log.info("Create hash for migration %s:%s", t.name, hashes_by_name[t.name])
+            end
+        end
+    end
+end
+
+return {
+    check_applied_migrations_not_changed = check_applied_migrations_not_changed,
+    update_applied_migrations_hashes = update_applied_migrations_hashes,
+    create_hashes_for_migrations = create_hashes_for_migrations,
+    DEFAULT_IS_APPLIED_MIGRATIONS_WRITABLE = DEFAULT_IS_APPLIED_MIGRATIONS_WRITABLE,
+}

--- a/migrator/config-loader.lua
+++ b/migrator/config-loader.lua
@@ -1,4 +1,5 @@
 local fio = require('fio')
+local digest = require('digest')
 local checks = require('checks')
 local log = require('log')
 
@@ -41,6 +42,31 @@ function Loader:list()
     end
 
     __must_sort(result)
+
+    return result
+end
+
+function Loader:hashes_by_name(cfg)
+    -- cfg might be a new config from validate_config
+    -- if nil uses current active config
+    local ca = require("cartridge.confapplier")
+    cfg = cfg or ca.get_active_config():get_plaintext()
+    if cfg == nil then
+        return {}
+    end
+
+    local result = {}
+
+    for k, text in pairs(cfg) do
+        if k:startswith(self.config_section_name) then
+            local name = k:match("([^/]+)$")
+            if name ~= nil then
+                result[name] = digest.md5(text)
+            else
+                log.warn('Cannot load %s', k)
+            end
+        end
+    end
 
     return result
 end

--- a/migrator/directory-loader.lua
+++ b/migrator/directory-loader.lua
@@ -1,4 +1,5 @@
 local fio = require('fio')
+local digest = require('digest')
 local checks = require('checks')
 local log = require('log') -- luacheck: ignore
 
@@ -32,6 +33,29 @@ function Loader:list()
     return result
 end
 
+function Loader:hashes_by_name()
+    local result = {}
+
+    local search_folder = fio.pathjoin(package.searchroot(), self.dir_name)
+    if not fio.path.is_dir(search_folder) then error(('Path %s is not valid'):format(search_folder)) end
+    local files = fio.listdir(search_folder) or {}
+    for _, file_name in ipairs(files) do
+        local fh, err_open = fio.open(fio.pathjoin(search_folder, file_name), {'O_RDONLY'})
+        if err_open ~= nil then
+            log.warn('Cannot open file %s: %s', file_name, err_open)
+        else
+            local lua_code, err_read = fh:read()
+            if err_read ~= nil then
+                log.warn('Cannot read file %s: %s', file_name, err_read)
+            else
+                result[file_name] = digest.md5(lua_code)
+            end
+        end
+    end
+
+    return result
+end
+
 local function new(dir_name)
     checks('?string')
     dir_name = dir_name or 'migrations'
@@ -45,5 +69,3 @@ end
 return {
     new = new
 }
-
-

--- a/test/helper/utils.lua
+++ b/test/helper/utils.lua
@@ -60,6 +60,7 @@ local function cleanup(g)
                 if box.space._migrations ~= nil and box.space._migrations:truncate() ~= nil then
                     return false
                 end
+
                 return true
             ]]))
         end)

--- a/test/integration/check_roles_enabled_test.lua
+++ b/test/integration/check_roles_enabled_test.lua
@@ -10,41 +10,44 @@ local shared = require('test.helper.integration').shared
 
 local datadir = fio.pathjoin(shared.datadir, 'basic')
 
-g.cluster = cartridge_helpers.Cluster:new({
-    server_command = fio.pathjoin(shared.root, 'test', 'entrypoint', 'check_roles_enabled_init.lua'),
-    datadir = datadir,
-    use_vshard = true,
-    base_advertise_port = 10400,
-    base_http_port = 10090,
-    replicasets = {
-        {
-            alias = 'api',
-            uuid = cartridge_helpers.uuid('a'),
-            roles = { 'vshard-router', 'migrator' },
-            servers = { { alias='api-master', instance_uuid = cartridge_helpers.uuid('a', 1) } },
-        },
-        {
-            alias = 'storage-role1-role2',
-            uuid = cartridge_helpers.uuid('b'),
-            roles = { 'vshard-storage', 'cartridge.roles.role1', 'cartridge.roles.role2', 'migrator' },
-            servers = {
-                {
-                    alias = 'storage-role1-role2-master',
-                    instance_uuid = cartridge_helpers.uuid('b', 1),
-                    env = {TARANTOOL_HTTP_ENABLED = 'false'},
-                },
-                {
-                    alias = 'storage-role1-role2-replica',
-                    instance_uuid = cartridge_helpers.uuid('b', 2),
-                    env = {TARANTOOL_HTTP_ENABLED = 'false'},
+g.before_all(function(cg)
+    cg.cluster = cartridge_helpers.Cluster:new({
+        server_command = fio.pathjoin(shared.root, 'test', 'entrypoint', 'check_roles_enabled_init.lua'),
+        datadir = datadir,
+        use_vshard = true,
+        replicasets = {
+            {
+                alias = 'api',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router' },
+                servers = { { alias='api-master', instance_uuid = cartridge_helpers.uuid('a', 1) } },
+            },
+            {
+                alias = 'storage-role1-role2',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage', 'cartridge.roles.role1', 'cartridge.roles.role2' },
+                servers = {
+                    {
+                        alias = 'storage-role1-role2-master',
+                        instance_uuid = cartridge_helpers.uuid('b', 1),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
+                    {
+                        alias = 'storage-role1-role2-replica',
+                        instance_uuid = cartridge_helpers.uuid('b', 2),
+                        env = {TARANTOOL_HTTP_ENABLED = 'false'},
+                    },
                 },
             },
         },
-    },
-})
+    })
+    cg.cluster:start()
+end)
 
-g.before_all(function(cg) cg.cluster:start() end)
-g.after_all(function(cg) cg.cluster:stop() end)
+g.after_all(function(cg)
+    cg.cluster:stop()
+    fio.rmtree(cg.cluster.datadir)
+end)
 
 g.test_check = function(cg)
     t.assert(cg.cluster:server('api-master'):exec(function() return require('migrator.utils').check_roles_enabled({'vshard-router'}) end))

--- a/test/integration/fockups_test.lua
+++ b/test/integration/fockups_test.lua
@@ -11,33 +11,36 @@ local utils = require("test.helper.utils")
 
 local datadir = fio.pathjoin(shared.datadir, 'basic')
 
-g.cluster = cartridge_helpers.Cluster:new({
-    server_command = shared.server_command,
-    datadir = datadir,
-    use_vshard = true,
-    base_advertise_port = 13400,
-    base_http_port = 8090,
-    replicasets = {
-        {
-            alias = 'api',
-            uuid = cartridge_helpers.uuid('a'),
-            roles = { 'vshard-router' },
-            servers = { { instance_uuid = cartridge_helpers.uuid('a', 1) } },
-        },
-        {
-            alias = 'storage-1',
-            uuid = cartridge_helpers.uuid('b'),
-            roles = { 'vshard-storage' },
-            servers = {
-                { instance_uuid = cartridge_helpers.uuid('b', 1), },
-                { instance_uuid = cartridge_helpers.uuid('b', 2), },
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = true,
+        replicasets = {
+            {
+                alias = 'api',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router' },
+                servers = { { instance_uuid = cartridge_helpers.uuid('a', 1) } },
+            },
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage' },
+                servers = {
+                    { instance_uuid = cartridge_helpers.uuid('b', 1), },
+                    { instance_uuid = cartridge_helpers.uuid('b', 2), },
+                },
             },
         },
-    },
-})
+    })
 
-g.before_all(function() g.cluster:start() end)
-g.after_all(function() g.cluster:stop() end)
+    g.cluster:start()
+end)
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
 g.after_each(function() utils.cleanup(g) end)
 
 g.test_drop = function()
@@ -133,10 +136,11 @@ end
 g.test_inconsistent_migrations = function()
     for _, server in pairs(g.cluster.servers) do
         server.net_box:eval([[
-                require('migrator').set_loader({
-                    list = function() return {} end
-                })
-            ]])
+            require('migrator').set_loader({
+                list = function(_) return {} end,
+                hashes_by_name = function(_) return {} end
+            })
+        ]])
     end
     g.cluster.main_server.net_box:eval([[
                 require('migrator').set_loader({
@@ -146,6 +150,11 @@ g.test_inconsistent_migrations = function()
                                 name = '102_local',
                                 up = function() return true end
                             },
+                        }
+                    end,
+                    hashes_by_name = function(_)
+                        return {
+                            ['102_local'] = 'hashXXX',
                         }
                     end
                 })

--- a/test/integration/is_applied_migrations_writable_test.lua
+++ b/test/integration/is_applied_migrations_writable_test.lua
@@ -1,0 +1,159 @@
+local t = require('luatest')
+local g = t.group()
+local fiber = require('fiber') -- luacheck: ignore
+
+local fio = require('fio')
+
+local cartridge_helpers = require('cartridge.test-helpers')
+
+local shared = require('test.helper.integration').shared
+local utils = require("test.helper.utils")
+
+local datadir = fio.pathjoin(shared.datadir, 'basic')
+
+g.before_all(function()
+    g.cluster = cartridge_helpers.Cluster:new({
+        server_command = shared.server_command,
+        datadir = datadir,
+        use_vshard = true,
+        replicasets = {
+            {
+                alias = 'api',
+                uuid = cartridge_helpers.uuid('a'),
+                roles = { 'vshard-router' },
+                servers = { { instance_uuid = cartridge_helpers.uuid('a', 1) } },
+            },
+            {
+                alias = 'storage-1',
+                uuid = cartridge_helpers.uuid('b'),
+                roles = { 'vshard-storage' },
+                servers = {
+                    { instance_uuid = cartridge_helpers.uuid('b', 1), env = {TARANTOOL_HTTP_ENABLED = 'false'} },
+                    { instance_uuid = cartridge_helpers.uuid('b', 2), env = {TARANTOOL_HTTP_ENABLED = 'false'} },
+                },
+            },
+            {
+                alias = 'storage-2',
+                uuid = cartridge_helpers.uuid('c'),
+                roles = { 'vshard-storage' },
+                servers = {
+                    { instance_uuid = cartridge_helpers.uuid('c', 1), env = {TARANTOOL_HTTP_ENABLED = 'false'} },
+                    { instance_uuid = cartridge_helpers.uuid('c', 2), env = {TARANTOOL_HTTP_ENABLED = 'false'} },
+                },
+            },
+        },
+    })
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+g.before_each(function()
+    for _, server in pairs(g.cluster.servers) do
+        server.net_box:eval([[
+            require('migrator').set_loader(
+                require('migrator.config-loader').new()
+            )
+        ]])
+    end
+
+    utils.set_sections(g, { { filename = "migrations/source/01_test.lua", content = [[
+return {
+    up = function()
+        return true
+    end
+}
+    ]]}})
+
+    require('fiber').sleep(0.5)
+
+    local result = g.cluster.main_server:http_request('post', '/migrations/up', { json = {} })
+    t.assert_equals(result.json, {
+        applied = {
+            ["api-1"] = {"01_test.lua"},
+            ["storage-1-1"] = {"01_test.lua"},
+            ["storage-2-1"] = {"01_test.lua"},
+        }
+    })
+    local cfg = g.cluster:download_config()
+    cfg.migrations = nil
+    g.cluster:upload_config(cfg)
+end)
+
+local function make_applied_migrations_writable()
+    local cfg = g.cluster:download_config()
+    cfg.migrations = cfg.migrations or {}
+    cfg.migrations.options = {
+        is_applied_migrations_writable = true,
+    }
+    g.cluster:upload_config(cfg)
+end
+
+local function make_applied_migrations_unwritable()
+    local cfg = g.cluster:download_config()
+    cfg.migrations = cfg.migrations or {}
+    cfg.migrations.options = {
+        is_applied_migrations_writable = false,
+    }
+    g.cluster:upload_config(cfg)
+end
+
+g.after_each(function()
+    -- make_applied_migrations_writable()
+    utils.cleanup(g)
+    make_applied_migrations_unwritable()
+end)
+
+g.test_error_apply_config_with_modified_migrations = function(cg)
+    t.assert_error_msg_contains("Modifying already applied migrations is not allowed.",
+        cg.cluster.main_server.graphql, g.cluster.main_server, { query = [[
+        mutation($sections: [ConfigSectionInput!]) {
+            cluster {
+                config(sections: $sections) {
+                    filename
+                    content
+                }
+            }
+        }]],
+        variables = { sections = {{
+            filename = "migrations/source/01_test.lua", content = [[
+                return {
+                    // some changes
+                    up = function()
+                        return true
+                    end
+                }
+            ]]
+        }} }
+    })
+end
+
+g.test_ok_apply_config_with_modified_migrations = function(cg)
+    make_applied_migrations_writable()
+    utils.set_sections(cg, { { filename = "migrations/source/01_test.lua", content = [[
+        return {
+            // some changes
+            up = function()
+                return true
+            end
+        }
+    ]]
+    }})
+end
+
+g.test_error_migrations_up = function(cg)
+    -- update hash manually in order to simulate changes
+    for _, s_name in pairs({'api-1', 'storage-1-1', 'storage-2-1'}) do
+        cg.cluster:server(s_name):exec(function()
+            box.space._migrations:update(1, {{'=', 'hash', 'changed'}})
+        end)
+    end
+
+    -- check migrations up call
+    local status, resp = cg.cluster.main_server:exec(function() return pcall(function() require('migrator').up() end) end)
+    t.assert_equals(status, false)
+    t.assert_str_contains(resp, "Modifying already applied migrations is not allowed.")
+end

--- a/test/integration/upgrade_test.lua
+++ b/test/integration/upgrade_test.lua
@@ -15,8 +15,6 @@ g.before_all(function()
         server_command = shared.server_command,
         datadir = datadir,
         use_vshard = false,
-        base_advertise_port = 13400,
-        base_http_port = 8090,
         replicasets = {
             {
                 alias = 'storage-1',
@@ -106,4 +104,3 @@ g.test_upgrade_clusterwide_applied_migrations_exist = function(cg)
     t.assert_not(status)
     t.assert_str_contains(tostring(resp), 'A list of applied migrations is found in cluster config')
 end
-

--- a/test/unit/apply_config_test.lua
+++ b/test/unit/apply_config_test.lua
@@ -22,4 +22,5 @@ g.test_apply_config_order = function()
     t.assert(pcall(migrator.init))
     t.assert(pcall(migrator.validate_config,{}, {}))
     t.assert(pcall(migrator.apply_config,{is_master = true}, {}))
+    package.setsearchroot(box.NULL)
 end

--- a/test/unit/apply_config_test.lua
+++ b/test/unit/apply_config_test.lua
@@ -1,0 +1,25 @@
+local t = require("luatest")
+local g = t.group()
+
+g.after_each(function()
+    if box.space._migrations ~= nil then
+        box.space._migrations:drop()
+    end
+end)
+
+g.test_apply_config_order = function()
+    box.ctl.on_schema_init(function()
+        box.space._space:on_replace(function(_, sp)
+            if sp.name == '_migrations' then
+
+                require('fiber').sleep(3)
+            end
+        end)
+    end)
+    local migrator = require('migrator')
+    package.setsearchroot("test/unit")
+    t.assert(pcall(migrator.validate_config,{}, {}))
+    t.assert(pcall(migrator.init))
+    t.assert(pcall(migrator.validate_config,{}, {}))
+    t.assert(pcall(migrator.apply_config,{is_master = true}, {}))
+end

--- a/test/unit/check_applied_migrations_not_changed_test.lua
+++ b/test/unit/check_applied_migrations_not_changed_test.lua
@@ -1,3 +1,6 @@
+-- These tests were ported from migrations-ee.
+-- Version numbers correspond to migrations-ee releases.
+
 local t = require('luatest')
 local changing_applied_migrations = require('migrator.changing-applied-migrations')
 local vars = require('cartridge.vars').new('migrator')

--- a/test/unit/check_applied_migrations_not_changed_test.lua
+++ b/test/unit/check_applied_migrations_not_changed_test.lua
@@ -1,0 +1,116 @@
+local t = require('luatest')
+local changing_applied_migrations = require('migrator.changing-applied-migrations')
+local vars = require('cartridge.vars').new('migrator')
+
+
+local function create_migration_space_1_3_0()
+    -- after release 1_3_0 added field 'hash' in _migrations space
+    box.schema.sequence.create('_migrations_id_seq', { if_not_exists = true })
+    box.schema.create_space('_migrations', {
+        if_not_exists = true,
+    })
+
+    box.space._migrations:format({
+        {'id', type='unsigned', is_nullable=false},
+        {'name', type='string', is_nullable=false},
+        {'hash', type='string', is_nullable=true},
+    })
+
+    box.space._migrations:create_index('primary', {
+        sequence = '_migrations_id_seq',
+        if_not_exists = true,
+    })
+
+    if box.space._migrations.index.primary ~= nil
+    and box.space._migrations.index.primary.sequence_id == nil then
+        box.space._migrations.index.primary:alter({sequence = '_migrations_id_seq'})
+    end
+end
+
+local function create_migration_space_1_2_0()
+    -- before release 1_3_0 there were only id and name fields
+    box.schema.sequence.create('_migrations_id_seq', { if_not_exists = true })
+    box.schema.create_space('_migrations', {
+        if_not_exists = true,
+    })
+
+    box.space._migrations:format({
+        {'id', type='unsigned', is_nullable=false},
+        {'name', type='string', is_nullable=false},
+    })
+
+    box.space._migrations:create_index('primary', {
+        sequence = '_migrations_id_seq',
+        if_not_exists = true,
+    })
+
+    if box.space._migrations.index.primary ~= nil
+    and box.space._migrations.index.primary.sequence_id == nil then
+        box.space._migrations.index.primary:alter({sequence = '_migrations_id_seq'})
+    end
+end
+
+local g = t.group()
+
+g.before_all(function()
+    vars.loader = {
+        hashes_by_name = function()
+            return {
+                ["001.lua"] = 'HASH',
+            }
+        end
+    }
+end)
+
+g.after_all(function()
+    vars.loader = nil
+end)
+
+g.after_each(function()
+    if box.space._migrations ~= nil then
+        box.space._migrations:drop()
+    end
+end)
+
+g.test_empty_ok_1_2_0 = function()
+    create_migration_space_1_2_0()
+    changing_applied_migrations.check_applied_migrations_not_changed()
+end
+
+g.test_empty_ok_1_3_0 = function()
+    create_migration_space_1_3_0()
+    changing_applied_migrations.check_applied_migrations_not_changed()
+end
+
+g.test_error = function()
+    create_migration_space_1_3_0()
+    box.space._migrations:replace({
+        1, '001.lua', 'NOT EQUAL HASH'
+    })
+    t.assert_error_msg_contains(
+        'Modifying already applied migrations is not allowed',
+        changing_applied_migrations.check_applied_migrations_not_changed
+    )
+end
+
+g.test_ok_no_hash_field = function()
+    create_migration_space_1_2_0()
+    box.space._migrations:replace({
+        1, '001.lua'
+    })
+    changing_applied_migrations.check_applied_migrations_not_changed()
+end
+
+g.test_skip_is_applied_migrations_writable = function()
+    create_migration_space_1_3_0()
+    box.space._migrations:replace({
+        1, '001.lua', 'NOT EQUAL HASH'
+    })
+
+    local orig = changing_applied_migrations.__is_applied_migrations_writable
+    changing_applied_migrations.__is_applied_migrations_writable = function ()
+        return true
+    end
+    changing_applied_migrations.check_applied_migrations_not_changed()
+    changing_applied_migrations.__is_applied_migrations_writable = orig
+end


### PR DESCRIPTION
Added new migration behavior: by default, applied migrations cannot be edited, otherwise the config will not apply.

To allow editing applied migrations, a new flag `options.is_applied_migrations_writable` has been introduced, which defaults to `false`.